### PR TITLE
Implement native CPIO/zstd generator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,6 +251,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
+name = "cpio"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80e3adec7390c7643049466136117057188edf5f23efc5c8b4fc8079c8dc34a6"
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -520,10 +526,13 @@ version = "0.0.6"
 dependencies = [
  "clap",
  "colored",
+ "cpio",
  "humane_commands",
  "kmoddep",
  "nix",
  "profile",
+ "walkdir",
+ "zstd",
 ]
 
 [[package]]

--- a/microgen/Cargo.toml
+++ b/microgen/Cargo.toml
@@ -13,6 +13,7 @@ clap = { version = "4.5.4", features = [
     "wrap_help",
 ] }
 colored = "2.1.0"
+cpio = "0.4.0"
 humane_commands = "0.1.2"
 kmoddep = "0.1.3"
 #kmoddep = { path = "../../kmoddep" }
@@ -53,3 +54,5 @@ nix = { version = "0.28.0", features = [
 ] }
 
 profile = { path = "../profile" }
+walkdir = "2.5.0"
+zstd = "0.13.1"

--- a/microgen/src/main.rs
+++ b/microgen/src/main.rs
@@ -1,5 +1,6 @@
 mod clidef;
 mod rdgen;
+mod rdpack;
 
 use clap::Error;
 use colored::Colorize;

--- a/microgen/src/rdgen.rs
+++ b/microgen/src/rdgen.rs
@@ -161,7 +161,7 @@ impl IrfsGen {
 
         let out = self.dst_fn.as_os_str().to_str().unwrap();
         println!("Writing the initramfs to {:?}", out);
-        rdpack::pack(out);
+        rdpack::pack(out)?;
 
         env::set_current_dir(here)?;
         fs::remove_dir_all(&self.dst)?;

--- a/microgen/src/rdgen.rs
+++ b/microgen/src/rdgen.rs
@@ -6,8 +6,9 @@ use std::{
     io::{BufWriter, Error, ErrorKind::InvalidData, Write},
     os::unix::fs::{symlink, PermissionsExt},
     path::{Path, PathBuf},
-    process::Command,
 };
+
+use crate::rdpack;
 
 const MICROHOP: &[u8] = include_bytes!("microhop");
 const BLINKENLICHTEN: &str = "# Achtung Alles Lookenskepers!
@@ -158,14 +159,9 @@ impl IrfsGen {
         let here = env::current_dir()?;
         env::set_current_dir(self.dst.as_path())?;
 
-        println!("Writing the initrd to {:?}", self.dst_fn.as_os_str());
-        let mut p = Command::new("/usr/bin/bash");
-        p.arg("-c")
-            .arg(format!(
-                "find . -print0 | cpio --null -ov --format=newc | zstd > ../{}",
-                self.dst_fn.as_os_str().to_str().unwrap()
-            ))
-            .output()?;
+        let out = self.dst_fn.as_os_str().to_str().unwrap();
+        println!("Writing the initramfs to {:?}", out);
+        rdpack::pack(out);
 
         env::set_current_dir(here)?;
         fs::remove_dir_all(&self.dst)?;

--- a/microgen/src/rdpack.rs
+++ b/microgen/src/rdpack.rs
@@ -38,35 +38,22 @@ impl InitRamfsPacker {
         let mut data: Vec<u8> = vec![];
 
         let f_meta = fs::metadata(&pth).unwrap();
-        let arc_meta;
+        let mut arc_meta = NewcBuilder::new(p).ino(inode).uid(0).gid(f_meta.gid()).mode(f_meta.permissions().mode());
+
         if pth.is_symlink() {
             data.extend(fs::read_link(pth).unwrap().to_str().unwrap().as_bytes());
-            arc_meta = NewcBuilder::new(p)
-                .ino(inode)
-                .uid(0)
-                .gid(f_meta.gid())
-                .mode(f_meta.permissions().mode())
-                .set_mode_file_type(cpio::newc::ModeFileType::Symlink);
+            arc_meta = arc_meta.set_mode_file_type(cpio::newc::ModeFileType::Symlink);
         } else if pth.is_file() {
             data.extend(fs::read(&pth)?);
-            arc_meta = NewcBuilder::new(p)
-                .ino(inode)
-                .uid(0)
-                .gid(f_meta.gid())
-                .mode(f_meta.permissions().mode())
-                .set_mode_file_type(cpio::newc::ModeFileType::Regular);
+            arc_meta = arc_meta.set_mode_file_type(cpio::newc::ModeFileType::Regular);
         } else {
-            arc_meta = NewcBuilder::new(p)
-                .ino(inode)
-                .uid(0)
-                .gid(f_meta.gid())
-                .mode(f_meta.permissions().mode())
-                .set_mode_file_type(cpio::newc::ModeFileType::Directory);
+            arc_meta = arc_meta.set_mode_file_type(cpio::newc::ModeFileType::Directory);
         }
 
         Ok((arc_meta, data))
     }
 
+    /// Pack initramfs into a file
     fn pack(&mut self, output: &str) -> Result<(), Error> {
         self.get_content();
 

--- a/microgen/src/rdpack.rs
+++ b/microgen/src/rdpack.rs
@@ -1,0 +1,96 @@
+use cpio::{newc::trailer, NewcBuilder};
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
+use std::{
+    fs::{self, File},
+    io::{self, BufWriter, Cursor, Error, Write},
+    path::PathBuf,
+    vec,
+};
+use walkdir::WalkDir;
+use zstd::stream::write::Encoder;
+
+/// Packs initramfs to CPIO archive
+struct InitRamfsPacker {
+    path: String,
+    files: Vec<PathBuf>,
+}
+
+impl InitRamfsPacker {
+    fn new(p: &str) -> Self {
+        {
+            InitRamfsPacker { path: p.to_string(), files: vec![] }
+        }
+    }
+
+    /// Find all the required files
+    fn get_content(&mut self) {
+        self.files = WalkDir::new(&self.path)
+            .follow_links(true)
+            .into_iter()
+            .flatten()
+            .map(|e| e.path().to_owned())
+            .collect::<Vec<PathBuf>>();
+    }
+
+    /// Build file metadata and information for the CPIO archive
+    fn file_loader(inode: u32, p: &str) -> io::Result<(NewcBuilder, Vec<u8>)> {
+        let pth = PathBuf::from(p);
+        let mut data: Vec<u8> = vec![];
+
+        let f_meta = fs::metadata(&pth).unwrap();
+        let arc_meta;
+        if pth.is_symlink() {
+            data.extend(fs::read_link(pth).unwrap().to_str().unwrap().as_bytes());
+            arc_meta = NewcBuilder::new(p)
+                .ino(inode)
+                .uid(0)
+                .gid(f_meta.gid())
+                .mode(f_meta.permissions().mode())
+                .set_mode_file_type(cpio::newc::ModeFileType::Symlink);
+        } else if pth.is_file() {
+            data.extend(fs::read(&pth)?);
+            arc_meta = NewcBuilder::new(p)
+                .ino(inode)
+                .uid(0)
+                .gid(f_meta.gid())
+                .mode(f_meta.permissions().mode())
+                .set_mode_file_type(cpio::newc::ModeFileType::Regular);
+        } else {
+            arc_meta = NewcBuilder::new(p)
+                .ino(inode)
+                .uid(0)
+                .gid(f_meta.gid())
+                .mode(f_meta.permissions().mode())
+                .set_mode_file_type(cpio::newc::ModeFileType::Directory);
+        }
+
+        Ok((arc_meta, data))
+    }
+
+    fn pack(&mut self, output: &str) {
+        self.get_content();
+
+        let all_data: Vec<u8> = vec![];
+        let cur = Cursor::new(all_data);
+        let mut out = BufWriter::new(cur);
+
+        let mut inode = 1;
+        for fp in &self.files {
+            let (bdr, data) = InitRamfsPacker::file_loader(inode, fp.to_str().unwrap()).unwrap();
+            let mut w = bdr.write(&mut out, data.len() as u32);
+            w.write_all(&data);
+            w.finish().unwrap();
+            inode += 1;
+        }
+
+        let out = trailer(out).unwrap();
+        let mut encoder = Encoder::new(File::create(format!("../{}", output)).unwrap(), 10).unwrap();
+        encoder.write_all(&out.into_inner().unwrap().into_inner());
+        encoder.finish();
+    }
+}
+
+/// Pack a content of a path into a CPIO archive
+pub fn pack(p: &str) -> Result<(), Error> {
+    Ok(InitRamfsPacker::new(".").pack(p))
+}


### PR DESCRIPTION
This PR:
- Drops the reliance to shell-out using external tools
- Implements native CPIO pack with zstandard compression
- Makes even smaller initrd 😉 