### PR TITLE
Bugfix: dependencies ordering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,9 +436,9 @@ dependencies = [
 
 [[package]]
 name = "kmoddep"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8924e65c2342cf4d35662166564a0cea57232bc5ee336af13d4783c1dfcb6c2b"
+checksum = "154db096c4c633bee0537320084b28b55427d65ea97800c3c9b5d6e241e072d3"
 
 [[package]]
 name = "lazy_static"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,7 +522,7 @@ dependencies = [
 
 [[package]]
 name = "microgen"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "clap",
  "colored",
@@ -537,7 +537,7 @@ dependencies = [
 
 [[package]]
 name = "microhop"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "chrono",
  "colored",
@@ -634,7 +634,7 @@ dependencies = [
 
 [[package]]
 name = "profile"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "indexmap",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "microhop"
-version = "0.0.7"
+version = "0.0.8"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/bumpver.toml
+++ b/bumpver.toml
@@ -1,5 +1,5 @@
 [bumpver]
-current_version = "0.0.7"
+current_version = "0.0.8"
 version_pattern = "MAJOR.MINOR.PATCH"
 commit_message = "Release to version {new_version}"
 tag_message = "{new_version}"

--- a/microgen/Cargo.toml
+++ b/microgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "microgen"
-version = "0.0.7"
+version = "0.0.8"
 edition = "2021"
 
 [dependencies]

--- a/microgen/Cargo.toml
+++ b/microgen/Cargo.toml
@@ -15,7 +15,7 @@ clap = { version = "4.5.4", features = [
 colored = "2.1.0"
 cpio = "0.4.0"
 humane_commands = "0.1.2"
-kmoddep = "0.1.3"
+kmoddep = "0.1.4"
 #kmoddep = { path = "../../kmoddep" }
 nix = { version = "0.28.0", features = [
     "kmod",

--- a/profile/Cargo.toml
+++ b/profile/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile"
-version = "0.0.7"
+version = "0.0.8"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/microhop.rs
+++ b/src/microhop.rs
@@ -4,7 +4,7 @@ use profile::cfg::MhConfig;
 use std::io::Error;
 use uuid::Uuid;
 
-static VERSION: &str = "0.0.7";
+static VERSION: &str = "0.0.8";
 
 // Mount required system dirs
 lazy_static! {


### PR DESCRIPTION
Ensure that generated `/etc/microhop.conf` lists kernel modules in the order of first dependencies, and only then base modules.