### PR TITLE
Remove lazy_static dependency and fix syslib docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -369,9 +369,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin",
-]
 
 [[package]]
 name = "lazycell"
@@ -464,7 +461,6 @@ name = "microhop"
 version = "0.1.0"
 dependencies = [
  "colored",
- "lazy_static",
  "log",
  "nix",
  "profile",
@@ -731,12 +727,6 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,8 +49,6 @@ zstd = "0.13.1"
 profile = { path = "profile" }
 syslib = { path = "syslib" }
 uuid = "1.8.0"
-lazy_static = { version = "1.4.0", features = ["spin"] }
-
 
 [profile.release]
 strip = true

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,7 @@ fn main() -> Result<(), Error> {
         log::debug!("Init sysroot path: {}", temp_mpt);
     }
 
-    mount_fs(&SYS_MPT);
+    mount_fs(SYS_MPT);
 
     let (root_fstype, blk_mpt) = get_blk_devices(&cfg)?;
     if root_fstype.is_empty() {
@@ -41,9 +41,9 @@ fn main() -> Result<(), Error> {
 
     // Remount sysfs, switch root
     log::debug!("switching root");
-    for t in &*SYS_MPT {
-        let tgt = format!("{}{}", temp_mpt, t.2);
-        nix::mount::mount(Some(t.2.as_str()), tgt.as_str(), Some(t.0.as_str()), MsFlags::MS_MOVE, Option::<&str>::None)?;
+    for t in SYS_MPT {
+        let tgt = format!("{}{}", temp_mpt, t.dst);
+        nix::mount::mount(Some(t.dst), tgt.as_str(), Some(t.fstype), MsFlags::MS_MOVE, Option::<&str>::None)?;
     }
 
     // Pivot the system

--- a/syslib/src/fs.rs
+++ b/syslib/src/fs.rs
@@ -1,8 +1,7 @@
-/*
-Utilities for the root filesystem operations.
-This module is intended to do all the basic operations those are typically
-done by external utils, such as mount, umount, switch root etc.
-*/
+//! Utilities for the root filesystem operations.
+//!
+//! This module is intended to do all the basic operations those are typically
+//! done by external utils, such as mount, umount, switch root etc.
 
 use nix::{mount::MsFlags, sys::statvfs, unistd};
 use std::{fs, io::Error};


### PR DESCRIPTION
Remove the need for the `lazy_static` dependency by using `&'static str` instead of `String` in globals, and fix some docs that were not properly picked up by rustdoc.