### PR TITLE
Build fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .DEFAULT_GOAL := build
 .PHONY:build microhop-release-static microhop-debug-static microgen-release microgen-debug _reset_placeholder
 
-ARCH := $(shell uname -p)
+ARCH := $(shell uname -m)
 ARC_VERSION := $(shell cat src/microhop.rs | grep 'static VERSION' | sed -e 's/.*=//g' -e 's/[" ;]//g')
 ARC_NAME := microhop-${ARC_VERSION}
 

--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,10 @@ ARC_VERSION := $(shell cat src/microhop.rs | grep 'static VERSION' | sed -e 's/.
 ARC_NAME := microhop-${ARC_VERSION}
 
 microhop-release-static:
-	RUSTFLAGS='-C target-feature=+crt-static' cargo build -p microhop --target $(ARCH)-unknown-linux-gnu --release
+	RUSTFLAGS='-C target-feature=+crt-static' cargo build -p microhop --target $(ARCH)-unknown-linux-musl --release
 
 microhop-debug-static:
-	RUSTFLAGS='-C target-feature=+crt-static' cargo build -p microhop --target $(ARCH)-unknown-linux-gnu
+	RUSTFLAGS='-C target-feature=+crt-static' cargo build -p microhop --target $(ARCH)-unknown-linux-musl
 
 microgen-release:
 	cargo build -p microgen --release
@@ -25,7 +25,7 @@ build-debug:
 	@printf "Building Microhop (debug)\n"
 	@$(MAKE) microhop-debug-static
 
-	cp target/$(ARCH)-unknown-linux-gnu/debug/microhop microgen/src
+	cp target/$(ARCH)-unknown-linux-musl/debug/microhop microgen/src
 
 	@printf "Building Microgen\n"
 	@$(MAKE) microgen-debug
@@ -37,7 +37,7 @@ build-release:
 	@printf "Building Microhop (release)\n"
 	@$(MAKE) microhop-release-static
 
-	cp target/$(ARCH)-unknown-linux-gnu/release/microhop microgen/src
+	cp target/$(ARCH)-unknown-linux-musl/release/microhop microgen/src
 
 	@printf "Building Microgen\n"
 	@$(MAKE) microgen-release


### PR DESCRIPTION
@isbm Let's start with simple things, then we can dispatch the Rust and Nix codebase ;-)

These two patches were in the the `fixes` branch for long time.

The `uname` fix caused previously:
```
make build-release
Building Microhop (release)
make[1]: Entering directory '/home/pethod/microhop'
RUSTFLAGS='-C target-feature=+crt-static' cargo build -p microhop --target unknown-unknown-linux-gnu --release
error: failed to run `rustc` to learn about target-specific information

Caused by:
  process didn't exit successfully: `rustc - --crate-name ___ --print=file-names -C target-feature=+crt-static --target unknown-unknown-linux-gnu --crate-type bin --crate-type rlib --crate-type dylib --crate-type cdylib --crate-type staticlib --crate-type proc-macro --print=sysroot --print=split-debuginfo --print=crate-name --print=cfg -Wwarnings` (exit status: 1)
  --- stderr
  error: error loading target specification: could not find specification for target "unknown-unknown-linux-gnu"
    |
    = help: run `rustc --print target-list` for a list of built-in targets

make[1]: *** [Makefile:9: microhop-release-static] Error 101
make[1]: Leaving directory '/home/pethod/microhop'
make: *** [Makefile:38: build-release] Error 2
```

```
$ uname -p
unknown
$ uname -m
x86_64
```

Second change is about the libc. If the target is statically linked then there should be no need to use gnu glibc and switch to musl libc instead.

Any thoughts?